### PR TITLE
Hide guest frontpage sections

### DIFF
--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -114,8 +114,11 @@ $themesettings = new \theme_moove\util\settings();
 
 $templatecontext = array_merge($templatecontext, $themesettings->footer());
 
+
 $template = 'theme_moove/drawers';
-if (!isloggedin()) {
+
+// Display front page sections only for logged-in users.
+if (isloggedin()) {
     $templatecontext = array_merge($templatecontext, $themesettings->frontpage());
 
     $template = 'theme_moove/frontpage';


### PR DESCRIPTION
## Summary
- only render Moove frontpage sections when logged in

## Testing
- `php -l layout/frontpage.php`


------
https://chatgpt.com/codex/tasks/task_e_6887fdcfa370832681e264afbc51f34d